### PR TITLE
Fix home dir for www-data user

### DIFF
--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -45,7 +45,8 @@ RUN mkdir -p /tmp/mhsendmail \
 RUN pip3 install awscli segno --no-cache-dir
 
 # Configure www-data user as primary php-fpm user for better local dev experience
-RUN chmod 0755 ~www-data \
+RUN usermod -d /home/www-data www-data \
+    && chmod 0755 ~www-data \
     && mkdir -p /var/www/html \
     && chown www-data:www-data /var/www/html \
     && echo "www-data ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd \


### PR DESCRIPTION
This change fixes the incorrect path to the www-data user. As a result of the wrong path - the composer all the time asks for composer repositories credentials.

On the original warden images, home directory is `/home/www-data`. You can test it by the following commands:
```
warden shell
cd ~/
pwd
```

Actual result on multi-arch images:
```
/var/www
```

Expected result (similar to original images):
```
/home/www-data
```