### PR TITLE
Fix incorrect check for ssh agent

### DIFF
--- a/images/php-fpm/context/docker-entrypoint
+++ b/images/php-fpm/context/docker-entrypoint
@@ -15,7 +15,7 @@ fi
 sudo update-ca-certificates
 
 # start socat process in background to connect sockets used for agent access within container environment
-if [ -s /run/host-services/ssh-auth.sock ] \
+if [ -S /run/host-services/ssh-auth.sock ] \
   && [ "${SSH_AUTH_SOCK}" != "/run/host-services/ssh-auth.sock" ]
 then
   sudo rm -f "${SSH_AUTH_SOCK}"


### PR DESCRIPTION
Socat wasn't started due to incorrect check in the entrypoint, so you basically can't connect to GitHub via ssh.
```bash
www-data@magento2-php-fpm:/var/www/html$ ssh git@gitbhub.com
git@bitbucket.org: Permission denied (publickey).
```

After the fix:
```
www-data@magento2-php-fpm:/var/www/html$ ssh git@github.com
Warning: Permanently added the ECDSA host key for IP address '140.82.121.4' to the list of known hosts.
PTY allocation request failed on channel 0
Hi ihor-sviziev! You've successfully authenticated, but GitHub does not provide shell access.
Connection to github.com closed.
```
It was broken since https://github.com/drpayyne/warden-multi-arch/commit/95e86d92405b435868db6b3bdbecc6002c0e3910#diff-b2afe4b0cd0174d9e69200c8e8a99e3f45dcf6c33a8298e7613f333515bef785R18