### PR TITLE
No need for recursive chown

### DIFF
--- a/images/php-fpm/context/docker-entrypoint
+++ b/images/php-fpm/context/docker-entrypoint
@@ -54,10 +54,10 @@ for DIR in ${CHOWN_DIR_LIST:-}; do
   fi
 done
 
-# Resolve permission issue with /var/www being owned by root as a result of volume mounted on php-fpm
+# Resolve permission issue with /var/www/html being owned by root as a result of volume mounted on php-fpm
 # and nginx combined with nginx running as a different uid/gid than php-fpm does. This condition, when it
 # surfaces would cause mutagen sync failures (on initial startup) on macOS environments.
-sudo chown -R www-data:www-data /var/www
+sudo chown www-data:www-data /var/www/html
 
 # first arg is `-f` or `--some-option`
 if [ "${1#-}" != "$1" ]; then


### PR DESCRIPTION
This PR reverts https://github.com/drpayyne/warden-multi-arch/commit/7bf03f19319440c7d6460f570cf6bb5483ecf9f3
Looks like after fixing the home directory in https://github.com/drpayyne/warden-multi-arch/pull/17 and https://github.com/drpayyne/warden-multi-arch/pull/18 we don't need to 

Reason - recursive chmod on big projects (for instance, M2 project with 20+ GB of media folder) is a pretty slow operation, so it is better to do it only if needed.

Looks like that was the actual reason for https://github.com/davidalger/warden/issues/486