### PR TITLE
Add image for Elasticsearch 7.10.1

### DIFF
--- a/images/elasticsearch/7.10/Dockerfile
+++ b/images/elasticsearch/7.10/Dockerfile
@@ -1,0 +1,3 @@
+FROM elasticsearch:7.10.1
+RUN bin/elasticsearch-plugin install analysis-phonetic \
+    && bin/elasticsearch-plugin install analysis-icu


### PR DESCRIPTION
Adds image for Elasticsearch 7.10.1, [required for Magento 2.4.3](https://devdocs.magento.com/guides/v2.4/install-gde/system-requirements.html). This is the [highest version Adobe Cloud Commerce will support](https://support.magento.com/hc/en-us/articles/4419942355725-Switching-to-OpenSearch-for-Adobe-Commerce-on-Cloud-2-4-4) for Magento 2.4.4. Perhaps requires addition of package ghcr.io/drpayyne/warden-elasticsearch:7.10 if I'm reading things correctly.