### PR TITLE
fix wrong varnish image version

### DIFF
--- a/.github/workflows/docker-image-varnish.yml
+++ b/.github/workflows/docker-image-varnish.yml
@@ -94,7 +94,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: images/varnish/context
-          file: images/varnish/7.1/Dockerfile
+          file: images/varnish/7.0/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |


### PR DESCRIPTION
Wrong version in varnish 7.0. (7.1 instead of 7..0 in github workflow)