### PR TITLE
fix comparison for support with sh

### DIFF
--- a/images/php-fpm/magento2/Dockerfile
+++ b/images/php-fpm/magento2/Dockerfile
@@ -9,7 +9,7 @@ RUN npm install -g grunt-cli gulp yarn
 
 RUN set -eux \
     && PHP_VERSION=$(php -v | head -n1 | cut -d' ' -f2 | awk -F '.' '{print $1$2}') \
-    && if (( ${PHP_VERSION} >= 72 )); \
+    && if [ $PHP_VERSION -ge 72 ]; \
         then MAGERUN_PHAR_URL=https://files.magerun.net/n98-magerun2.phar; \
         else MAGERUN_PHAR_URL=https://files.magerun.net/n98-magerun2-3.2.0.phar; \
     fi \
@@ -19,7 +19,7 @@ RUN set -eux \
 
 RUN set -eux \
     && PHP_VERSION=$(php -v | head -n1 | cut -d' ' -f2 | awk -F '.' '{print $1$2}') \
-    && if (( ${PHP_VERSION} >= 72 )); \
+    && if [ $PHP_VERSION -ge 72 ]; \
         then MAGERUN_BASH_REF=master; \
         else MAGERUN_BASH_REF=3.2.0; \
     fi \


### PR DESCRIPTION
Original comparison operator works only for bash. Default shell is sh.