### PR TITLE
Fix issue where MySQLi module isn't loaded for Wordpress environments

### DIFF
--- a/images/php-fpm/Dockerfile
+++ b/images/php-fpm/Dockerfile
@@ -22,6 +22,9 @@ RUN npm install -g n \
     && n install ${NODE_VERSION} \
     && rm -rf /usr/local/n/versions/node
 
+# Install & Enable MySQLi for WordPress sites
+RUN docker-php-ext-install mysqli
+
 COPY docker-entrypoint /usr/local/bin/
 COPY etc/profile.d/*.sh /etc/profile.d/
 COPY etc/*.ini /etc/


### PR DESCRIPTION
There's an error when setting up wordpress-sites (and any other applications using `mysqli` ), as mysqli is not installed in the images. This should install it using the `docker-php-ext-install` utility. The official warden-images also have mysqli included.

This should close #26 .